### PR TITLE
Add more meeting information

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Outside of the UCG repo, much of the team's discussion happens [in the `#t-opsem
 
 ### Meetings
 
-The team holds weekly meetings on jitsi: <https://meet.jit.si/ucg-rust>. The meeting is currently
-scheduled for Tuesdays at noon, Boston time. You can see what time that is in your timezone
-[here](https://everytimezone.com/s/53a200c0).
+The team holds weekly meetings. For details around scheduling and format, see the [dedicated
+page](meetings.md).
 
 ## Code of Conduct and licensing
 

--- a/meetings.md
+++ b/meetings.md
@@ -1,0 +1,39 @@
+## Meetings
+
+Team meetings are currently held every Tuesday at noon, Boston time. You can see what time that is
+in your timezone [here](https://everytimezone.com/s/53a200c0). The meetings take place on jitsi:
+<https://meet.jit.si/ucg-rust>.
+
+On the third Tuesday of every month we skip our regular meeting in exchange for asynchronous
+planning. During this time, we pick meeting topics for the upcoming timeslots from our pool of open
+[meeting proposals]. Upcoming meetings are listed below.
+
+[meeting proposals]: https://github.com/rust-lang/opsem-team/issues?q=is%3Aissue+is%3Aopen+label%3Ameeting-proposal
+
+Anyone with a topic that they would like to see covered should feel free to [file a
+proposal][meeting template].
+
+[meeting template]: https://github.com/rust-lang/opsem-team/issues/new?assignees=&labels=meeting-proposal&template=meeting_proposal.md&title=%28My+meeting+proposal%29
+
+Meetings will typically have a champion - someone responsible for driving the meeting and preparing
+any design documents to read. This person will typically be the same person that wrote the proposal
+(although that is not a hard requirement). Additionally, someone will be given the responsibility of
+taking notes.
+
+
+#### Upcoming Meetings
+
+* 2023-05-09: Documentation and resources for unsafe code. [Issue](https://github.com/rust-lang/opsem-team/issues/4)
+    * Champion: ?
+        * Alternatives if no champion can be found: [Match & UnsafeCell](https://github.com/rust-lang/opsem-team/issues/5) or backlog bonanza
+    * Note taker: ?
+* 2023-05-02: Generator optimizations. [Issue](https://github.com/rust-lang/opsem-team/issues/3)
+    * Champion: Jakob
+    * Note taker: ?
+* 2023-04-25: UCG Backlog Bonanza
+    * Champion: Jakob
+    * Note taker: ?
+
+#### Past Meetings
+
+* 2023-04-18: Initial planning. [Minutes](https://hackmd.io/qNSeMDDGTTGMki1qzDEurA).


### PR DESCRIPTION
This mostly documents the result of the discussion this morning.

The only additional thing that I've done here that wasn't discussed is decided to also write down past and upcoming meetings here - the thought being that we'll use the bottom of the page as a log that can just grow over time. Main reason for doing it this way is that it means all the information is in one place and fairly easy to keep up to date.

r? @rust-lang/opsem 